### PR TITLE
fix type hint for connect

### DIFF
--- a/nats/__init__.py
+++ b/nats/__init__.py
@@ -18,7 +18,7 @@ from .aio.client import Client as NATS
 
 
 async def connect(
-    servers: Union[List[str]] = ["nats://localhost:4222"], **options
+    servers: Union[str, List[str]] = ["nats://localhost:4222"], **options
 ) -> NATS:
     """
     :param servers: List of servers to connect.


### PR DESCRIPTION
This PR fixes the type hint for `.connect()` (the shortcut in `__init__.py`) so that it matches `Client.connect` in that it accepts a string as value for the `servers` argument.  